### PR TITLE
Fixed Issue

### DIFF
--- a/src/components/ColumnPage.js
+++ b/src/components/ColumnPage.js
@@ -74,7 +74,7 @@ const ColumnPage = ({day, setAuth, unsavedChanges, setUnsavedChanges, setSaveUpd
             <div className="list-group">
                 {columns.map((column, index) => {
                     return (
-                        <Column setAuth={setAuth} key={index} setIsOffline={setIsOffline} address={address} unsavedChanges={unsavedChanges} setUnsavedChanges={setUnsavedChanges} setSaveUpdate={setSaveUpdate} saveUpdate={saveUpdate} setUpdate={setUpdate} update={update} _id={column._id} title={column.title} organizer={column.organizer} day={day} time={column.time}></Column>
+                        <Column setAuth={setAuth} key={column._id} setIsOffline={setIsOffline} address={address} unsavedChanges={unsavedChanges} setUnsavedChanges={setUnsavedChanges} setSaveUpdate={setSaveUpdate} saveUpdate={saveUpdate} setUpdate={setUpdate} update={update} _id={column._id} title={column.title} organizer={column.organizer} day={day} time={column.time}></Column>
                     );
                 })}
             </div>


### PR DESCRIPTION
React uses the key prop to identify components in a list and determine which components need to be updated or re-rendered. If a new column is rendered with the same key as an existing column, React will update the existing column with the new props, but it will not reset the state of the column's child components.

Key was not unique -> column state values were not reset bc columns were not re rendered