### PR TITLE
Fixed viewer mode on previews

### DIFF
--- a/src/components/dedicatedviewer/ColumnView.js
+++ b/src/components/dedicatedviewer/ColumnView.js
@@ -7,7 +7,6 @@ const ColumnViewer = ({ day, setDay, address }) => {
   const [columns, setColumns] = useState([]);
 
   function viewerUpdate() {
-    console.log(process.env.REACT_APP_DEPLOYMENT_URL);
     const requestOptions = {
       method: "GET",
       headers: {

--- a/src/components/dedicatedviewer/ColumnView.js
+++ b/src/components/dedicatedviewer/ColumnView.js
@@ -7,6 +7,7 @@ const ColumnViewer = ({ day, setDay, address }) => {
   const [columns, setColumns] = useState([]);
 
   function viewerUpdate() {
+    console.log(process.env.REACT_APP_DEPLOYMENT_URL);
     const requestOptions = {
       method: "GET",
       headers: {

--- a/src/components/dedicatedviewer/WeatherView.js
+++ b/src/components/dedicatedviewer/WeatherView.js
@@ -10,6 +10,7 @@ const Weather = ({ address }) => {
   useEffect(() => {
     fetch(`${address}/weather`, {
       headers: {
+        "Content-Type": "application/json",
         "vercel-deployment-url": process.env.REACT_APP_DEPLOYMENT_URL,
       },
       credentials: "include",


### PR DESCRIPTION
Earlier, all previews were returning a 403 forbidden because the vercel-deployment-url was not being sent correctly. 